### PR TITLE
graphite-client: fix error shown in error

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ $ npm install
 
 ## Usage
 
-See the [`example/`](./example) directory.
+See the [`example/`](./example) directory.  You can start up the example app
+with the following.  Supply your own [Hosted Graphite](https://www.hostedgraphite.com)
+key.
+
+```shell
+$ NODE_ENV=production ENVIRONMENT=production HOSTEDGRAPHITE_APIKEY=[valid-key] DEBUG=* DEBUGMETRICS=1 PORT=5000 node example/app.js
+```
 
 
 ## Environment variables

--- a/lib/graphite/client.js
+++ b/lib/graphite/client.js
@@ -21,12 +21,14 @@ const _ = require('lodash'),
 // Sends a set of metrics to Graphite
 Graphite.prototype.log = function (metrics) {
     debug(`Flush has been called ${this.flushCounter}`);
+
     this.flushCounter ++;
+
     if (this.flushCounter % 10 === 0) {          //show the message every 10 times
         this.loggingMessageDisplayed = false;
     }
 
-    if (!this.loggingMessageDisplayed) {
+    if (!this.loggingMessageDisplayed && !this.isLogging) {
         debug('Logging to Graphite is disabled by default on non-production environments. To enable is set ENVIRONMENT to "production". Or set DEBUGMETRICS=1 to debug metric counters');
         this.loggingMessageDisplayed = true;
     }

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -42,7 +42,7 @@ Metrics.prototype.init = function (opts) {
         isLogging = (process.env.DEBUGMETRICS === '1');
 
     isLogging = isLogging || isProduction;
-console.log(`isLogging is: ${isLogging}`);
+
     if (!apiKey && (isLogging)) {
         throw 'No HOSTEDGRAPHITE_APIKEY is set. Please set a false one if you are on your localhost.';
     }

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -42,7 +42,7 @@ Metrics.prototype.init = function (opts) {
         isLogging = (process.env.DEBUGMETRICS === '1');
 
     isLogging = isLogging || isProduction;
-
+console.log(`isLogging is: ${isLogging}`);
     if (!apiKey && (isLogging)) {
         throw 'No HOSTEDGRAPHITE_APIKEY is set. Please set a false one if you are on your localhost.';
     }


### PR DESCRIPTION
The first flush always falls into the loggingMessageDisplayed condition
at least once before getting itself set properly.  Added a check to
require isLogging to also be false for this condition to be met.  This
prevents the message that logging is off being displayed on startup when
logging is actually on.

Fixes: #8

cc: @MatthewJonD @MDrooker 