### PR TITLE
update latest package deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,17 +28,17 @@
   },
   "dependencies": {
     "debug": "2.2.0",
-    "lodash": "4.11.1",
+    "lodash": "4.12.0",
     "metrics": "0.1.9",
     "nconf": "0.8.4"
   },
   "devDependencies": {
-    "changelog-maker": "2.2.2",
-    "esdoc": "0.4.6",
-    "eslint": "2.7.0",
+    "changelog-maker": "2.2.3",
+    "esdoc": "0.4.7",
+    "eslint": "2.10.2",
     "jq-cli-wrapper": "0.3.0",
     "jsonlint": "1.6.2",
-    "npm-check-updates": "2.6.2"
+    "npm-check-updates": "2.6.5"
   },
   "keywords": [
     "cnn",


### PR DESCRIPTION
# Why

Updating the latest deps

```
lodash              😎  MINOR UP  Minor update available. https://lodash.com/
                                 npm install --save lodash@4.12.0 to go from 4.5.0 to 4.12.0

changelog-maker     😎  PATCH UP  Patch update available. https://github.com/rvagg/changelog-maker#readme
                                 npm install --save-dev changelog-maker@2.2.3 to go from 2.2.0 to 2.2.3

esdoc               😎  NEW VER!  NonSemver update available. https://esdoc.org/
                                 npm install --save-dev esdoc@0.4.7 to go from 0.4.5 to 0.4.7

eslint              😎  MINOR UP  Minor update available. http://eslint.org
                                 npm install --save-dev eslint@2.10.2 to go from 2.1.0 to 2.10.2

npm-check-updates   😎  MINOR UP  Minor update available. https://github.com/tjunnone/npm-check-updates
                                 npm install --save-dev npm-check-updates@2.6.5 to go from 2.5.8 to 2.6.5
```