### PR TITLE
Adds ENV var check for appName

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -44,6 +44,7 @@ Metrics.prototype.init = function (opts) {
     opts = opts || this.opts;
 
     let self = this,
+        appName = (opts.appName || process.env.APPNAME || '').toLowerCase(),
         appType = (opts.appType || process.env.APPTYPE || '').toLowerCase(),
         options,
         customer = (opts.customer || process.env.CUSTOMER || '').toLowerCase(),
@@ -99,7 +100,7 @@ Metrics.prototype.init = function (opts) {
     _.merge(self.opts, opts);
 
     // Verify some options
-    if (!self.opts.appName) {
+    if (!appName) {
         throw 'You need to specify an application name (appName) in the configuration options or set an environment var (APPNAME).';
     }
     if (isLogging && !customer) {
@@ -110,7 +111,7 @@ Metrics.prototype.init = function (opts) {
     }
 
     options = {
-        appName: self.opts.appName.toLowerCase(),  // Give the app a name
+        appName: appName,          // Give the app a name
         hostname: hostname,        // What host it is running on
         platform: platform,        // is it docker, kub, local
         customer: customer,        // is it cnn, coredev, mss, etc.
@@ -124,7 +125,7 @@ Metrics.prototype.init = function (opts) {
 
     if (self.hostedGraphiteKey !== null) {
         self.graphite = new Graphite({
-            prefix: util.format('%s.%s.%s.%s.%s.', platform, hostname,  product, environment, self.opts.app || self.opts.appName),
+            prefix: util.format('%s.%s.%s.%s.%s.', platform, hostname,  product, environment, self.opts.app || appName),
             options: options,
             keys: self.hostedGraphiteKey,
             isLogging: isLogging


### PR DESCRIPTION
**What** - adds appName check for ENV var

**Why** - line 102 throws, saying if one isn't in `opts` it should be set as an ENV var but no check was ever performed. 
